### PR TITLE
Fix blueprint import link encoding

### DIFF
--- a/website/src/components/blueprints_docs/BlueprintImportCard.jsx
+++ b/website/src/components/blueprints_docs/BlueprintImportCard.jsx
@@ -26,8 +26,8 @@ function BlueprintImportCard({ category, id }) {
             <h5>My Home Assistant</h5>
             <p>
               <a
-                href={`https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=${escape(
-                  url
+                href={`https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=${encodeURIComponent(
+                  url,
                 )}`}
                 target='_blank'
                 rel='noreferrer'


### PR DESCRIPTION
## Summary
- use `encodeURIComponent` instead of deprecated `escape` when generating import link

## Testing
- `npx prettier --check website/src/components/blueprints_docs/BlueprintImportCard.jsx`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_684068a26b0c832682307e17565f3404